### PR TITLE
Declarative syntax

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,12 @@ typeschema
 .. automodule:: typeschema.typeschema
    :members:
 
+****************
+typeschema.model
+****************
+.. automodule:: typeschema.model
+   :members:
+
 *********************
 typeschema.decorators
 *********************

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -1,0 +1,47 @@
+import unittest
+from mock import Mock
+
+from typeschema import model as mod
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.definition_params = {
+            'foo': (Mock(return_value='foo_prop'), (), {'default':0}),
+            'bar': (Mock(return_value='bar_prop'), (), {}),
+        }
+        self.definitions = {
+            'foo': self._get_define('foo'),
+            'bar': self._get_define('bar'),
+        }
+        self.attrs = {
+            'ignored': "ignored value"
+        }
+
+    def _get_define(self, name):
+        prop, args, kwargs = self.definition_params[name]
+        return mod.Define(prop, *args, **kwargs)
+
+    def test_model_meta_is_correct_instance(self):
+        cls = self.get_example_class()
+        self.assertIsInstance(cls._meta, mod.Meta)
+
+    def test_model_meta_has_correct_definitions(self):
+        cls = self.get_example_class()
+        definitions = cls._meta.definitions
+        self.assertEqual(definitions, self.definitions)
+
+    def test_model_meta_has_correct_properties(self):
+        cls = self.get_example_class()
+        for name, prop in cls._meta.properties.items():
+            mock, args, kwargs = self.definition_params[name]
+            self.assertEqual(prop, mock.return_value)
+            mock.assert_called_once_with(name, *args, **kwargs)
+
+    def get_example_class(self):
+        class Example(mod.Model):
+            foo = self.definitions['foo']
+            bar = self.definitions['bar']
+            ignored = self.attrs['ignored']
+
+        return Example

--- a/typeschema/model.py
+++ b/typeschema/model.py
@@ -1,27 +1,25 @@
 """
-Declarative Model syntax for simpler typeschema use
-
 typeschema.models defines useful classes that allow for declarative syntax
-for objects with typeschema properties. A simple example looks like this.
+for objects with ``typeschema`` properties. A simple example looks like this.
 
-import typeschema.properties as ts
+>>> import typeschema.properties as ts
 
-class Example(Model):
-    foo = Define(ts.int, default=0)
-    bar = Define(ts.string)
+>>> class Example(Model):
+...     foo = Define(ts.int, default=0)
+...     bar = Define(ts.string)
 
 Metaclass magic makes it possible to omit the name of the property. Instances of
-Example will have foo and bar properties, which will be instances of typeschema.int
-and typeschema.string respectively.
+``Example`` will have ``foo`` and ``bar`` properties, which will be instances of
+``typeschema.int`` and ``typeschema.string`` respectively.
 
-The Example class will also get a _meta attribute, instance of the Meta class
+The ``Example`` class will also get a ``_meta`` attribute, instance of the ``Meta`` class
 (see below). This class contains information about the way the model was declared.
 
 """
 
 class Define(object):
     """
-    Wraps a typeschema.property when using Model declarative syntax.
+    Wraps a ``typeschema.property`` when using ``Model`` declarative syntax.
     All arguments and keyword arguments are used to instantiate the property.
     """
     def __init__(self, propclass, *args, **kwargs):
@@ -39,8 +37,8 @@ class Define(object):
 
 class Meta(object):
     """
-    Holds information about the definitions (Define instances) and properties
-    (property instances) that belong to a Model. Attributes:
+    Holds information about the definitions (``Define`` instances) and properties
+    (``property`` instances) that belong to a ``Model``. Attributes:
 
     properties: a dict of name: property
     definitions: a dict of name: Define
@@ -53,8 +51,8 @@ class Meta(object):
 class ModelMeta(type):
     """
     Metaclass thas makes the declarative syntax possible. Replaces class-level
-    instances of Define with instances of property, and sets _meta to the proper
-    Meta instance.
+    instances of ``Define`` with instances of ``property``, and sets ``_meta`` to the proper
+    ``Meta`` instance.
     """
 
     def __new__(cls, cls_name, bases, attrs):

--- a/typeschema/model.py
+++ b/typeschema/model.py
@@ -1,0 +1,89 @@
+"""
+Declarative Model syntax for simpler typeschema use
+
+typeschema.models defines useful classes that allow for declarative syntax
+for objects with typeschema properties. A simple example looks like this.
+
+import typeschema.properties as ts
+
+class Example(Model):
+    foo = Define(ts.int, default=0)
+    bar = Define(ts.string)
+
+Metaclass magic makes it possible to omit the name of the property. Instances of
+Example will have foo and bar properties, which will be instances of typeschema.int
+and typeschema.string respectively.
+
+The Example class will also get a _meta attribute, instance of the Meta class
+(see below). This class contains information about the way the model was declared.
+
+"""
+
+class Define(object):
+    """
+    Wraps a typeschema.property when using Model declarative syntax.
+    All arguments and keyword arguments are used to instantiate the property.
+    """
+    def __init__(self, propclass, *args, **kwargs):
+        self.name = None # set during metaclass __new__
+        self.propclass = propclass
+        self.args = args
+        self.kwargs = kwargs
+
+    def get_property(self):
+        if self.name is None:
+            raise RuntimeError('Unititialized name for Define')
+
+        return self.propclass(self.name, *self.args, **self.kwargs)
+
+
+class Meta(object):
+    """
+    Holds information about the definitions (Define instances) and properties
+    (property instances) that belong to a Model. Attributes:
+
+    properties: a dict of name: property
+    definitions: a dict of name: Define
+    """
+    def __init__(self):
+        self.properties = {}
+        self.definitions = {}
+
+
+class ModelMeta(type):
+    """
+    Metaclass thas makes the declarative syntax possible. Replaces class-level
+    instances of Define with instances of property, and sets _meta to the proper
+    Meta instance.
+    """
+
+    def __new__(cls, cls_name, bases, attrs):
+        new_attrs = { '_meta': Meta() }
+
+        for name, attr in attrs.items():
+            if isinstance(attr, Define):
+                attr.name = name
+                cls._update_attrs_from_definition(new_attrs, attr)
+            else:
+                new_attrs[name] = attr
+
+        return type.__new__(cls, cls_name, bases, new_attrs)
+
+    @classmethod
+    def _update_attrs_from_definition(cls, attrs, definition):
+        property = definition.get_property()
+        attrs[definition.name] = property
+        meta = attrs['_meta']
+        meta.properties[definition.name] = property
+        meta.definitions[definition.name] = definition
+
+
+class Model(object):
+    """
+    Base class for all classes that intend to use the declarative syntax for properties
+    """
+    __metaclass__ = ModelMeta
+
+    @classmethod
+    def definitions(cls):
+        return dict(cls._meta.definitions)


### PR DESCRIPTION
Add declarative syntax for properties. This PR lets us do this:
```
>>> import typeschema.properties as ts
>>> import typeschema.model as mod
>>> class A(mod.Model):
...     foo = mod.Define(ts.int, default=0)
...
>>> type(A.foo)
<class 'typeschema.properties.int'>
>>> A().foo
0
>>>
```

It uses metaclasses to perform some dark magic and autogenerate the properties.
